### PR TITLE
Fixed initialization bug due to change to `Environment.__init__()` in RLBench  

### DIFF
--- a/colosseum/rlbench/extensions/environment.py
+++ b/colosseum/rlbench/extensions/environment.py
@@ -49,43 +49,21 @@ class EnvironmentExt(Environment):
         path_task_ttms: str = DEFAULT_PATH_TTMS,
         env_config: DictConfig = DictConfig({}),
     ):
-        # HACK: This is a workaround for the case of using RLBench from PerAct
-        arg_count: int = len(inspect.signature(Environment.__init__).parameters)
-        if arg_count == 12:
-            # Using implementation from RLBench fork from PerAct
-            super().__init__(
-                action_mode,
-                dataset_root,
-                obs_config,
-                headless,
-                static_positions,
-                robot_setup,
-                randomize_every,  # type: ignore
-                frequency,
-                vis_random_config,  # type: ignore
-                dyn_random_config,  # type: ignore
-                attach_grasped_objects,
-            )
-        elif arg_count == 13:
-            # Using implementation from RLBench upstream repo
-            super().__init__(
-                action_mode,
-                dataset_root,
-                obs_config,
-                headless,
-                static_positions,
-                robot_setup,
-                randomize_every,  # type: ignore
-                frequency,
-                vis_random_config,  # type: ignore
-                dyn_random_config,  # type: ignore
-                attach_grasped_objects,
-                shaped_rewards,  # type: ignore
-            )
-        else:
-            raise RuntimeError(
-                "Unexpected number of arguments in Environment.__init__"
-            )
+        # Note that Environment has arguments `arm_max_velocity: float = 1.0, arm_max_acceleration: float = 4.0`
+        super().__init__(
+            action_mode,
+            dataset_root,
+            obs_config,
+            headless,
+            static_positions,
+            robot_setup,
+            randomize_every,  # type: ignore
+            frequency,
+            vis_random_config,  # type: ignore
+            dyn_random_config,  # type: ignore
+            attach_grasped_objects,
+            shaped_rewards,  # type: ignore
+        )
 
         self._path_task_ttms: str = path_task_ttms
         self._use_variations: bool = use_variations


### PR DESCRIPTION
Previously:
```
(aldarobots)  jstm ~/Projects/alda_robots (jm_dec2/colosseum) python scripts/collect_rlbench_demo.py --config-name $ENV_ID
Error executing job with overrides: []
Traceback (most recent call last):
  File "/home/jstm/Projects/alda_robots/scripts/collect_rlbench_demo.py", line 41, in main
    rlbench_env = EnvironmentExt(
  File "/home/jstm/miniconda3/envs/aldarobots/lib/python3.10/site-packages/colosseum/rlbench/extensions/environment.py", line 86, in __init__
    raise RuntimeError(
RuntimeError: Unexpected number of arguments in Environment.__init__: 15. Args: ['self', 'action_mode', 'dataset_root', 'obs_config', 'headless', 'static_positions', 'robot_setup', 'randomize_every', 'frequency', 'visual_randomization_config', 'dynamics_randomization_config', 'attach_grasped_objects', 'shaped_rewards', 'arm_max_velocity', 'arm_max_acceleration']

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```


The change to `Environment` is that there are now two more arguments to `__init__()`: `arm_max_velocity: float = 1.0,                 arm_max_acceleration: float = 4.0`, but the logic doesn't count them

```python
class Environment(object):
    """Each environment has a scene."""

    def __init__(self,
                 action_mode: ActionMode,
                 dataset_root: str = '',
                 obs_config: ObservationConfig = ObservationConfig(),
                 headless: bool = False,
                 static_positions: bool = False,
                 robot_setup: str = 'panda',
                 randomize_every: RandomizeEvery = None,
                 frequency: int = 1,
                 visual_randomization_config: VisualRandomizationConfig = None,
                 dynamics_randomization_config: DynamicsRandomizationConfig = None,
                 attach_grasped_objects: bool = True,
                 shaped_rewards: bool = False,
                 arm_max_velocity: float = 1.0,
                 arm_max_acceleration: float = 4.0,
                 ):
```